### PR TITLE
Feature/logging for logstash

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,10 +266,20 @@ func main() {
 		if *command != "" {
 			log.WithField("command", *command).Info("Running update command")
 			cmd := exec.Command("/bin/bash", "-c", *command) // #nosec
-			err := cmd.Run()
+			boutput, err := cmd.CombinedOutput()
+			output := string(boutput)
 			if err != nil {
-				log.WithError(err).WithField("cmd", cmd).Fatal("Unable to run cmd")
+				log.WithError(err).WithFields(log.Fields{
+					"cmd":     cmd,
+					"command": *command,
+					"output":  output}).Fatal("Unable to run cmd")
+			} else {
+				log.WithFields(log.Fields{
+					"command": *command,
+					"output":  output,
+				}).Info("Command ran succesfully")
 			}
+
 		}
 		log.Info("Certificates and key updated")
 		return true

--- a/main.go
+++ b/main.go
@@ -135,6 +135,7 @@ func main() {
 		formatter := &log.JSONFormatter{
 			FieldMap: log.FieldMap{
 				log.FieldKeyTime: "@timestamp",
+				log.FieldKeyMsg:  "@message",
 			}}
 		log.SetFormatter(formatter)
 	}
@@ -283,7 +284,7 @@ func main() {
 	for {
 		sleepInterval := time.Duration(time.Duration(float64(certTTL.Seconds())*
 			(1.0-*renewalCoefficient)+1) * time.Second)
-		log.WithFields(log.Fields{"sleep": sleepInterval}).Info("Sleeping")
+		log.WithFields(log.Fields{"duration": sleepInterval}).Info("Sleeping until next update of certificate")
 		time.Sleep(sleepInterval)
 		possibleRenew()
 	}


### PR DESCRIPTION
Add logstash compatible message field.
Use same `duration` logging field for all sleeps.
Better logging of command outputs.

Happy path json output will be:
```
bash-4.2# bin/keepsake     -cn keepsake.com     -certFile keepsake.crt     -keyFile keepsake.key     -caFile keepsake.ca     -vault-role keepsake     -cmd 'echo updated'     -certTTL=1m -once -json
{"@message":"Renewal Interval of Cert","@timestamp":"2018-03-26T11:37:56Z","certRenewalInterval":54000000000,"level":"info"}
{"@message":"Sleeping until Vault Token Renewal","@timestamp":"2018-03-26T11:37:56Z","duration":2488252500000000,"level":"info"}
{"@message":"Certificate Expire DateTime","@timestamp":"2018-03-26T11:37:56Z","NotAfter":"2018-03-26T11:38:20Z","level":"info"}
{"@message":"Running update command","@timestamp":"2018-03-26T11:37:56Z","command":"echo updated","level":"info"}
{"@message":"Command ran succesfully","@timestamp":"2018-03-26T11:37:56Z","command":"echo updated","level":"info","output":"updated\n"}
{"@message":"Certificates and key updated","@timestamp":"2018-03-26T11:37:56Z","level":"info"}
```

### with failing command

json output looks like this:
```
bash-4.2# bin/keepsake     -cn keepsake.com     -certFile keepsake.crt     -keyFile keepsake.key     -caFile keepsake.ca     -vault-role keepsake     -cmd 'asdf updated'     -certTTL=1m -once -json
{"@message":"Renewal Interval of Cert","@timestamp":"2018-03-26T11:38:24Z","certRenewalInterval":54000000000,"level":"info"}
{"@message":"Sleeping until Vault Token Renewal","@timestamp":"2018-03-26T11:38:24Z","duration":2488226400000000,"level":"info"}
{"@message":"Certificate Expire DateTime","@timestamp":"2018-03-26T11:38:24Z","NotAfter":"2018-03-26T11:38:26Z","level":"info"}
{"@message":"Running update command","@timestamp":"2018-03-26T11:38:25Z","command":"asdf updated","level":"info"}
{"@message":"Unable to run cmd","@timestamp":"2018-03-26T11:38:25Z","cmd":{"Path":"/bin/bash","Args":["/bin/bash","-c","asdf updated"],"Env":null,"Dir":"","Stdin":null,"Stdout":{},"Stderr":{},"ExtraFiles":null,"SysProcAttr":null,"Process":{"Pid":32},"ProcessState":{}},"command":"asdf updated","error":"exit status 127","level":"fatal","output":"/bin/bash: asdf: command not found\n"}
```

Default human readable log format looks like this:

```
bash-4.2# bin/keepsake     -cn keepsake.com     -certFile keepsake.crt     -keyFile keepsake.key     -caFile keepsake.ca     -vault-role keepsake     -cmd 'asdf updated'     -certTTL=1m -once
INFO[0000] Renewal Interval of Cert                      certRenewalInterval=54s
INFO[0000] Sleeping until Vault Token Renewal            duration=691h10m21s
INFO[0000] Certificate Expire DateTime                   NotAfter=2018-03-26 11:38:54 +0000 UTC
INFO[0000] Running update command                        command="asdf updated"
FATA[0000] Unable to run cmd                             cmd=&{/bin/bash [/bin/bash -c asdf updated] []  <nil> /bin/bash: asdf: command not found
 /bin/bash: asdf: command not found
 [] <nil> 0xc4201fc180 exit status 127 <nil> <nil> true [0xc4201320a0 0xc4201320b8 0xc4201320b8] [0xc4201320a0 0xc4201320b8] [0xc4201320b0] [0x700b30] 0xc42014c9c0 <nil>} command="asdf updated" error="exit status 127" output="/bin/bash: asdf: command not found
"
```